### PR TITLE
Add implementation issue template and update .gitignore for documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/implementation_issue.md
+++ b/.github/ISSUE_TEMPLATE/implementation_issue.md
@@ -1,0 +1,29 @@
+---
+name: Implementation Issue
+description: Template for feature implementation issues (e.g., catalog page, details page, cart page)
+labels: feature
+assignees: ""
+---
+
+**Feature Title**
+A short, descriptive title for the feature (e.g., Implement Book Catalog Page).
+
+**Description**
+Describe the feature to be implemented and its purpose.
+
+**Tasks**
+
+- [ ] List the specific tasks required to implement the feature.
+
+**Acceptance Criteria**
+
+- [ ] List the criteria that must be met for the feature to be considered complete.
+
+**Priority**
+
+- [ ] High
+- [ ] Medium
+- [ ] Low
+
+**Additional Notes**
+Add any other relevant information or context.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the issues folder in documentation requirements
+/docs/requirements/issues/


### PR DESCRIPTION
Update to use github issue template. Issues are ignored under the /requirements/issues directory and should be manually entered.